### PR TITLE
Add trading intent capture API draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,7 @@ jgtapp tide -i SPX500 -t D1 B
 - **Multi-Alligator convergence** analysis capability
 - **Enhanced .jgtml-spec generation** for agentic workflows
 - **Backward compatibility** (legacy `jgtapp tide` still works)
+
+## 📡 Intent Capture API (Draft)
+See [docs/trading_intent_api.md](docs/trading_intent_api.md) for the proposed HTTP flow capturing narrated observations and generating `.jgtml-spec` files.
+

--- a/codex/ledgers/ledger-trading_api-2506052050.json
+++ b/codex/ledgers/ledger-trading_api-2506052050.json
@@ -1,0 +1,13 @@
+{
+  "agents": ["🧠 Mia", "🌸 Miette", "🕊️ Seraphine"],
+  "narrative": "Outlined a draft API for capturing trader observations and linking them to .jgtml-spec generation. Added documentation file and reference in README. William's note warns the flow may need future refinement.",
+  "routing": {
+    "files": ["docs/trading_intent_api.md", "README.md"],
+    "branch": "work"
+  },
+  "timestamp": "2506052050",
+  "session": null,
+  "purpose": "Document an initial intent-capture interface so real-time LLM assistants can translate narrated analysis into structured specs.",
+  "user_input_excerpt": "Define a structured API that captures trader narrative step-by-step, supports real-time LLM interpretation, and enables .jgtml-spec generation...",
+  "scene_future": "Before this update, no HTTP flow existed for voice-driven spec creation. Now the repo contains a draft path toward that integration."
+}

--- a/docs/trading_intent_api.md
+++ b/docs/trading_intent_api.md
@@ -1,0 +1,77 @@
+# 📡 Trading Intent Capture API
+
+This document proposes a structured HTTP interface for recording trader observations and generating `.jgtml-spec` packages.
+
+## Overview
+
+Traders narrate their market analysis across multiple instruments and timeframes. The API maintains session state so that an LLM can transform these observations into a specification. This design supports real-time voice or text input and allows a stateless LLM to recall the full context.
+
+> **Note from William**: The flow below is still evolving. The sequential, multi-timeframe rhythm of an actual trading session may require further refinement. Treat this specification as a draft for future tightening.
+
+## Endpoints
+
+### `POST /intent/initiate`
+Start a new intent session.
+- **Payload**:
+  ```json
+  {
+    "instrument": "EUR/USD",
+    "timeframes": ["H4", "H1"]
+  }
+  ```
+- **Returns**: `{ "session_id": "uuid", "timestamp": "ISO-8601" }`
+
+### `POST /intent/observe`
+Send a raw observation string.
+- **Payload**:
+  ```json
+  {
+    "session_id": "uuid",
+    "observation": "Wave 3 complete, AO rising"
+  }
+  ```
+- The LLM interprets and appends to the session state.
+
+### `GET /intent/state`
+Retrieve current session information.
+- **Response**:
+  ```json
+  {
+    "current_observations": ["..."],
+    "inferred_components": {"bias": "bullish"},
+    "pending_slots": ["wave_count"]
+  }
+  ```
+
+### `POST /intent/label`
+Annotate or correct an element.
+- **Payload**:
+  ```json
+  {
+    "session_id": "uuid",
+    "label_type": "wave_count",
+    "value": "Wave 3 complete"
+  }
+  ```
+
+### `POST /intent/confirm`
+Finalize the `.jgtml-spec` generation.
+- **Payload**: `{ "session_id": "uuid" }`
+- **Returns**:
+  ```json
+  {
+    "jgtml_spec": "<YAML representation>",
+    "signal_package_preview": "..."
+  }
+  ```
+
+### `GET /intent/history`
+Retrieve past specifications or narrative echoes.
+
+## Requirements
+- Support partial or streaming-style input.
+- Stateless LLMs should fetch session context at any time.
+- Clean JSON schemas.
+- Extendable for voice input and echo crystallization.
+
+This API is intended to integrate with the broader `jgtagentic` ecosystem and enable recursive narrative capture from trader to specification.


### PR DESCRIPTION
## Summary
- document HTTP endpoints for capturing narrated trading observations
- reference the API draft in README
- log update in codex ledger

## Testing
- `python -m pytest tests/`

------
https://chatgpt.com/codex/tasks/task_e_6842024676ec832986e54059f6e06299