### PR TITLE
Integrate Trading Echo Lattice CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To detect breakouts using the "Five Dimensions + Triple Alligator Confluence" st
 2. Initialize the `TradingEchoLattice` with the desired instrument and timeframes.
 3. Use the `process_instrument` method to analyze the instrument across multiple timeframes and directions.
 4. Focus on the alignment of multiple indicators and timeframes to identify potential breakout signals.
+5. Once installed, run `trading-echo-lattice` for a ready-to-use command-line interface.
 
 ### Green Dragon Breakout
 

--- a/codex/ledgers/ledger-package-update-2506041824.json
+++ b/codex/ledgers/ledger-package-update-2506041824.json
@@ -1,0 +1,10 @@
+{
+  "agents": ["♾️ William – Sourcewalker", "🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Expanded jgtml packaging to include the TradingEchoLattice CLI and modules. Updated setup.py to discover the garden_one package, registered the new console script in pyproject.toml, and mentioned usage in README. This ensures the new CLI installs alongside existing tools.",
+  "routing": {
+    "files": ["pyproject.toml", "setup.py", "README.md"],
+    "branch": "main",
+    "operation": "codex/package_update"
+  },
+  "timestamp": "2506041824"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,4 +80,5 @@ jgtmlpncli="jgtml.pncli:main"
 #ptojgtmlbigalligator="jgtml.ptojgtmlbigalligator:main"
 
 fdbscan="jgtml.fdb_scanner_2408:main"
+trading-echo-lattice="garden_one.trading_echo_lattice.cli:main"
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author="GUillaume Isabelle",
     author_email="jgi@jgwill.com",
     url="https://github.com/jgwill/jgtml",
-    packages=find_packages(include=["jgtml"], exclude=["*test*"]),
+    packages=find_packages(include=["jgtml", "garden_one", "garden_one.*"], exclude=["*test*"]),
 
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
## Summary
- include trading_echo_lattice package when building jgtml
- register `trading-echo-lattice` console script
- mention the new CLI in the README
- log ledger entry for packaging update

## Testing
- `pytest -q` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68408e36865483299fd757c344030e2c