### PR TITLE
Add complex trading simulation example

### DIFF
--- a/codex/ledgers/ledger-enhanced-simulation-2506072139.json
+++ b/codex/ledgers/ledger-enhanced-simulation-2506072139.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506072139",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Expanded the trading simulation to integrate FDB Pattern Intelligence and FDB Scanner capabilities. The scene now showcases how real-time scanning combines with historical intelligence to guide trade decisions, weaving richer context into the example.",
+  "purpose": "Address inline feedback by demonstrating use of all FDB related classes. The enhanced example serves as a bridge between random testing and true signal-driven trading flows.",
+  "files": ["examples/complex_trading_simulation.py"],
+  "routing": {"branch": "master", "path": "examples/complex_trading_simulation.py"},
+  "session": "shell",
+  "user_input": "Please address any inline comments on the diff, as well as any additional instructions below.\nEnsule to consider all the 'fdb' related classes such as the intelligence and scanner in to your examples.",
+  "future_scene": "Previously the repo provided a simple random trade simulator. Now developers can reference a fully wired example that loads pattern intelligence, fetches signals via the scanner, and scores them with the predictor, paving the way for automated bot experiments."
+}

--- a/codex/ledgers/ledger-example-docs-2506072158.json
+++ b/codex/ledgers/ledger-example-docs-2506072158.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506072158",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Documented the complex trading simulation example and linked it in the docs index. This clarifies how imports weave together FDB modules for a trading loop.",
+  "purpose": "Provide clear reference for developers using the new example. The diagrams map data flow and sequence so future contributors understand dependencies.",
+  "files": ["docs/complex_trading_simulation.md", "docs/index.md"],
+  "routing": {"branch": "master", "path": "docs"},
+  "session": "shell",
+  "user_input": "Observe the whole imports that your examples does and create documentations for your examples.  Use various mermaid diagrams into markdown",
+  "future_scene": "Before this doc, the example stood alone. Now the repository includes illustrated guidance, making it easier to adapt the simulation for trading experiments."
+}

--- a/codex/ledgers/ledger-simulation-2506070640.json
+++ b/codex/ledgers/ledger-simulation-2506070640.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506070640",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Created a complex trading simulation example that harnesses FDBSignalQualityPredictor to open and close random trades over a generated price series. The intent is to illustrate advanced usage of signal evaluation within a self-contained environment.",
+  "purpose": "Expand repository capabilities by demonstrating how to simulate trades using existing predictor logic. The setup showcases dynamic evaluation loops and profit tracking for educational or prototyping use.",
+  "files": ["examples/complex_trading_simulation.py"],
+  "routing": {"branch": "master", "path": "examples/complex_trading_simulation.py"},
+  "session": "shell",
+  "user_input": "make the most complex simulation and setup you can imagine",
+  "future_scene": "Before this script, the repo only provided building blocks for signal evaluation. Now developers can run a mock trading loop to test strategies and extend toward richer trading bots."
+}

--- a/docs/complex_trading_simulation.md
+++ b/docs/complex_trading_simulation.md
@@ -1,0 +1,53 @@
+# 🚀 Complex Trading Simulation Example
+
+This guide explains the purpose and structure of `examples/complex_trading_simulation.py`.
+It demonstrates how different FDB modules work together to simulate a trading loop.
+
+## 📦 Imports Used
+
+The example brings in the following modules:
+
+- `random` – random price changes
+- `datetime` – tracking trade timestamps
+- `List` – type hints for trade history
+- `FDBSignalQualityPredictor` – scores signals using ML intelligence
+- `FDBPatternIntelligence` – evaluates historical pattern performance
+- `generate_fresh_and_cache` – pulls real‑time signals from `FDBScanner`
+
+## 🗺️ Data Flow Overview
+
+```mermaid
+flowchart LR
+    Scanner["FDBScanner\n(generate_fresh_and_cache)"] --> Signal
+    PatternIntelligence["FDBPatternIntelligence"] --> Intelligence
+    SignalQuality["FDBSignalQualityPredictor"] --> Quality
+    Signal --> SignalQuality
+    Signal --> PatternIntelligence
+    Quality --> Simulation
+    Intelligence --> Simulation
+    subgraph "ComplexTradingSimulation"
+        Simulation["Trading Loop"]
+    end
+```
+
+## 📈 Trading Loop Sequence
+
+```mermaid
+sequenceDiagram
+    participant Sim as Simulation
+    participant Scan as FDBScanner
+    participant Intel as PatternIntelligence
+    participant Pred as SignalPredictor
+
+    Sim->>Scan: Request latest candle
+    Scan-->>Sim: Signal data
+    Sim->>Pred: evaluate_signal()
+    Pred-->>Sim: Quality score
+    Sim->>Intel: evaluate_fdb_signal()
+    Intel-->>Sim: Historical score
+    Sim->>Sim: Open/close trades based on scores
+```
+
+The sequence above shows how the simulation fetches data, scores it with both the predictor and pattern intelligence, and decides when to trade.
+
+Use this example as a starting point to build more advanced bots that rely on the FDB ecosystem.

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,7 @@ This handbook has everything you need to become a coding wizard with your Trinit
 
 ### 🚀 Start Your Adventure
 - [**Coding Adventure**](coding_adventure.md) - Go on an exciting coding quest with your Trinity friends!
+- [**Complex Trading Simulation Example**](complex_trading_simulation.md) - See FDB tools in action with a full trading loop.
 
 ### 🎨 Make It Your Own
 - [**Customize Your Trinity**](customize_trinity.md) - Change how your Trinity friends look and work!

--- a/examples/complex_trading_simulation.py
+++ b/examples/complex_trading_simulation.py
@@ -1,0 +1,81 @@
+import random
+from datetime import datetime
+from typing import List
+
+from jgtml.fdb_signal_quality_predictor import FDBSignalQualityPredictor
+
+class Trade:
+    def __init__(self, instrument: str, direction: str, price: float, quality: float):
+        self.instrument = instrument
+        self.direction = direction
+        self.entry_price = price
+        self.quality = quality
+        self.open_time = datetime.now()
+        self.close_time = None
+        self.exit_price = None
+        self.profit = 0.0
+
+    def close(self, price: float):
+        self.exit_price = price
+        self.close_time = datetime.now()
+        if self.direction == 'buy':
+            self.profit = price - self.entry_price
+        else:
+            self.profit = self.entry_price - price
+
+class ComplexTradingSimulation:
+    """Simulate a series of trades using FDBSignalQualityPredictor."""
+
+    def __init__(self, instrument: str = 'EUR-USD', timeframe: str = 'D1', days: int = 30):
+        self.instrument = instrument
+        self.timeframe = timeframe
+        self.days = days
+        self.predictor = FDBSignalQualityPredictor(data_path='samples')
+        self.history: List[Trade] = []
+        self.balance = 10_000.0
+
+    def _generate_market_data(self) -> List[float]:
+        prices = [1.0]
+        for _ in range(self.days):
+            prices.append(prices[-1] + random.uniform(-0.01, 0.01))
+        return prices
+
+    def _generate_signal(self):
+        return {
+            'signal_type': random.choice(['buy', 'sell']),
+            'strength': random.random(),
+            'context': random.choice(['fractal_breakout', 'trend_reversal', 'momentum_spike'])
+        }
+
+    def run(self):
+        prices = self._generate_market_data()
+        active_trade = None
+        for day in range(1, len(prices)):
+            price = prices[day]
+            signal = self._generate_signal()
+            quality = self.predictor.evaluate_signal(self.instrument, self.timeframe, signal)
+            score = quality['overall_quality_score']
+
+            if not active_trade and score > 60:
+                active_trade = Trade(self.instrument, signal['signal_type'], price, score)
+                print(f"Day {day}: OPEN {signal['signal_type']} at {price:.4f} (score {score:.1f})")
+            elif active_trade:
+                if (active_trade.direction == 'buy' and price - active_trade.entry_price > 0.005) or \
+                   (active_trade.direction == 'sell' and active_trade.entry_price - price > 0.005) or \
+                   score < 40:
+                    active_trade.close(price)
+                    self.balance += active_trade.profit
+                    self.history.append(active_trade)
+                    print(f"Day {day}: CLOSE at {price:.4f}, profit {active_trade.profit:.4f}")
+                    active_trade = None
+        if active_trade:
+            active_trade.close(prices[-1])
+            self.balance += active_trade.profit
+            self.history.append(active_trade)
+            print(f"Final day: CLOSE at {prices[-1]:.4f}, profit {active_trade.profit:.4f}")
+
+        print(f"Final balance: {self.balance:.2f}")
+
+if __name__ == '__main__':
+    sim = ComplexTradingSimulation()
+    sim.run()

--- a/examples/complex_trading_simulation.py
+++ b/examples/complex_trading_simulation.py
@@ -3,6 +3,8 @@ from datetime import datetime
 from typing import List
 
 from jgtml.fdb_signal_quality_predictor import FDBSignalQualityPredictor
+from jgtml.fdb_pattern_intelligence import FDBPatternIntelligence
+from jgtml.fdb_scanner_2408 import generate_fresh_and_cache
 
 class Trade:
     def __init__(self, instrument: str, direction: str, price: float, quality: float):
@@ -24,13 +26,25 @@ class Trade:
             self.profit = self.entry_price - price
 
 class ComplexTradingSimulation:
-    """Simulate a series of trades using FDBSignalQualityPredictor."""
+    """Simulate a series of trades leveraging FDB ecosystem tools.
+
+    This example ties together the **FDBPatternIntelligence** system,
+    the **FDBScanner** data fetcher, and the **FDBSignalQualityPredictor**.
+    It demonstrates how historical intelligence and real-time scanning can
+    guide a trading loop that opens and closes positions automatically.
+    """
 
     def __init__(self, instrument: str = 'EUR-USD', timeframe: str = 'D1', days: int = 30):
         self.instrument = instrument
         self.timeframe = timeframe
         self.days = days
+
+        # Historical intelligence used by the predictor
+        self.intelligence = FDBPatternIntelligence(data_path='samples')
+        self.intelligence.load_all_pattern_intelligence()
+
         self.predictor = FDBSignalQualityPredictor(data_path='samples')
+
         self.history: List[Trade] = []
         self.balance = 10_000.0
 
@@ -40,21 +54,44 @@ class ComplexTradingSimulation:
             prices.append(prices[-1] + random.uniform(-0.01, 0.01))
         return prices
 
-    def _generate_signal(self):
+    def _random_signal(self):
+        """Generate a random fallback signal."""
         return {
             'signal_type': random.choice(['buy', 'sell']),
             'strength': random.random(),
             'context': random.choice(['fractal_breakout', 'trend_reversal', 'momentum_spike'])
         }
 
+    def _scan_signal(self):
+        """Scan the latest market data using FDBScanner."""
+        try:
+            df = generate_fresh_and_cache(self.instrument.replace('-', '/'), self.timeframe)
+            last = df.iloc[-1]
+            if last.get('fdbb', 0) == 1:
+                sig_type = 'sell'
+            elif last.get('fdbs', 0) == 1:
+                sig_type = 'buy'
+            else:
+                return self._random_signal()
+
+            return {
+                'signal_type': sig_type,
+                'strength': abs(last.get('ao', 0)),
+                'context': 'scanner_realtime'
+            }
+        except Exception as e:
+            print(f"⚠️ Scanner failed: {e} -- using random signal.")
+            return self._random_signal()
+
     def run(self):
         prices = self._generate_market_data()
         active_trade = None
         for day in range(1, len(prices)):
             price = prices[day]
-            signal = self._generate_signal()
+            signal = self._scan_signal()
             quality = self.predictor.evaluate_signal(self.instrument, self.timeframe, signal)
-            score = quality['overall_quality_score']
+            intel = self.intelligence.evaluate_fdb_signal(self.instrument, self.timeframe, 'bull' if signal['signal_type'] == 'buy' else 'bear')
+            score = (quality['overall_quality_score'] + intel['signal_quality_score']) / 2
 
             if not active_trade and score > 60:
                 active_trade = Trade(self.instrument, signal['signal_type'], price, score)


### PR DESCRIPTION
## Summary
- craft a simulation that runs random trades through `FDBSignalQualityPredictor`
- log this change in a ledger for future reference

## Testing
- `pytest -q` *(fails: FileNotFoundError on test data)*

------
https://chatgpt.com/codex/tasks/task_e_68437b868e1c83298db0d34244f8ae72