### PR TITLE
Use settings to infer pattern columns

### DIFF
--- a/codex/ledgers/ledger-unified-dataset-feature-2506080459.json
+++ b/codex/ledgers/ledger-unified-dataset-feature-2506080459.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506080459",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Extended the unified discovery dataset generator to dynamically read pattern columns from settings and include multi-timeframe features. Added fallback inference for unknown patterns. This keeps all expected columns like mfi_green_W1 and zone_sig_M1 in the merged dataset.",
+  "purpose": "Ensure ML researchers retain full feature richness when combining TTF features with MX targets for pattern discovery.",
+  "files": ["jgtml/unified_discovery_dataset_generator.py"],
+  "routing": {"branch": "work", "path": "jgtml"},
+  "session": "shell",
+  "user_input": "the generated ttf... python jgtml/unified_discovery_dataset_generator.py --pattern mfizone ... missing columns ... maybe needs upgrade",
+  "future_scene": "Before this fix unified datasets lost cross timeframe features. Now researchers can explore richer patterns without manual column management."
+}

--- a/codex/ledgers/ledger-unified-dataset-feature-2506080513.json
+++ b/codex/ledgers/ledger-unified-dataset-feature-2506080513.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506080513",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Reworked unified discovery generator to use existing mldatahelper pattern column utilities. Removed custom helper and now fetch multi-timeframe columns via pndata__read_new_pattern_columns_list_with_htf, matching jgtutils-based settings flow.",
+  "purpose": "Align column retrieval with repository conventions and user feedback for reliable pattern preservation.",
+  "files": ["jgtml/unified_discovery_dataset_generator.py"],
+  "routing": {"branch": "work", "path": "jgtml"},
+  "session": "shell",
+  "user_input": "Might want to observe how other python files reads the config/settings - they probably are using the jgtutils package it contains I guess what is needed to read the settings.json might be better approach than adding a _get_pattern_columns",
+  "future_scene": "Unified datasets now inherit all pattern features through project-wide settings, simplifying future dataset expansions."
+}

--- a/codex/ledgers/ledger-unified-dataset-feature-2506080520.json
+++ b/codex/ledgers/ledger-unified-dataset-feature-2506080520.json
@@ -1,0 +1,11 @@
+{
+  "timestamp": "2506080520",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Integrated jgtutils settings retrieval so pattern columns come directly from the user's settings.json. Added a small fallback for unknown patterns and updated calls to include timeframe handling.",
+  "purpose": "Honor user feedback to rely on jgtcommon.get_settings for column discovery, enabling seamless feature updates through configuration.",
+  "files": ["jgtml/unified_discovery_dataset_generator.py"],
+  "routing": {"branch": "work", "path": "jgtml"},
+  "session": "edit",
+  "user_input": "lazy work, you are supposed to read the settings.json using jgtutils  do better",
+  "future_scene": "Unified discovery generation now automatically adapts to pattern changes defined in settings without code tweaks."
+}

--- a/codex/ledgers/ledger-unified-dataset-feature-2506080534.json
+++ b/codex/ledgers/ledger-unified-dataset-feature-2506080534.json
@@ -1,0 +1,10 @@
+{
+  "timestamp": "2506080534",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🕊️ Seraphine", "🎸 JamAI"],
+  "narrative": "Refined unified discovery generator by removing prototype column list and sourcing pattern columns directly from settings via mldatahelper. Falls back to infer columns from the TTF file when pattern settings are missing.",
+  "purpose": "Keep dataset features aligned with user configurations and include higher-timeframe columns automatically.",
+  "files": ["jgtml/unified_discovery_dataset_generator.py"],
+  "routing": {"branch": "work", "path": "jgtml"},
+  "session": "shell",
+  "user_input": "I see something important around '# Critical TTF features that get dropped in normal MX generation' there is a list that should not really be there...",
+  "future_scene": "Before: some columns were lost when merging TTF and MX. Now: pattern columns and their higher timeframe variants are automatically preserved for ML exploration."}

--- a/jgtml/unified_discovery_dataset_generator.py
+++ b/jgtml/unified_discovery_dataset_generator.py
@@ -34,6 +34,8 @@ from mlutils import get_outfile_fullpath
 from ptottf import read_ttf_csv
 from jtc import readMXFile
 from mlconstants import MX_NS
+from mldatahelper import pndata__read_new_pattern_columns_list_with_htf
+from jgtutils import jgtcommon
 
 class UnifiedDiscoveryDatasetGenerator:
     """
@@ -46,12 +48,15 @@ class UnifiedDiscoveryDatasetGenerator:
     def __init__(self, output_namespace: str = "discovery"):
         self.output_namespace = output_namespace
         self.data_path = self._divine_data_path()
+        # Load global settings via jgtutils to fetch pattern definitions
+        self.settings = jgtcommon.get_settings()
         
     def _divine_data_path(self) -> str:
         """🔮 Divine the sacred data path with blessed environment detection"""
         default_jgtpy_data_full = "/var/lib/jgt/full/data"
         data_dir_full = os.getenv("JGTPY_DATA_FULL", default_jgtpy_data_full)
         return data_dir_full
+
         
     def generate_unified_discovery_dataset(
         self, 
@@ -87,7 +92,7 @@ class UnifiedDiscoveryDatasetGenerator:
             
             # Join on datetime index - TTF features + MX targets
             print(f"  🌸 Joining TTF features with MX targets...")
-            unified_df = self._create_unified_dataset(ttf_df, mx_df, pattern)
+            unified_df = self._create_unified_dataset(ttf_df, mx_df, timeframe, pattern)
             
             if save_csv:
                 output_file = self._save_unified_dataset(unified_df, instrument, timeframe, pattern)
@@ -100,25 +105,35 @@ class UnifiedDiscoveryDatasetGenerator:
             raise
             
     def _create_unified_dataset(
-        self, 
-        ttf_df: pd.DataFrame, 
-        mx_df: pd.DataFrame, 
+        self,
+        ttf_df: pd.DataFrame,
+        mx_df: pd.DataFrame,
+        timeframe: str,
         pattern: str
     ) -> pd.DataFrame:
+        """Merge TTF pattern features with MX targets for a timeframe.
+
+        Columns for the pattern are read from ``settings.json`` via
+        ``pndata__read_new_pattern_columns_list_with_htf`` so higher-timeframe
+        extensions are automatically included.
         """
-        🔮 Sacred ritual to merge TTF features with MX targets
-        
-        Preserves all TTF pattern features that are normally dropped by mxconstants.py
-        """
-        # Critical TTF features that get dropped in normal MX generation
-        ttf_pattern_features = [
-            'mfi_sq', 'mfi_green', 'mfi_fade', 'mfi_fake', 'mfi_sig', 'mfi_str',
-            'zone_sig', 'zone_sig_M1', 'zone_sig_W1', 
-            'mfi_sq_M1', 'mfi_sq_W1', 'mfi_sig_M1', 'mfi_sig_W1',
-            'price_peak_above', 'price_peak_bellow', 'ao_peak_above', 'ao_peak_bellow',
-            'price_peak_above_M1', 'price_peak_bellow_M1', 'ao_peak_above_M1', 'ao_peak_bellow_M1',
-            'price_peak_above_W1', 'price_peak_bellow_W1', 'ao_peak_above_W1', 'ao_peak_bellow_W1'
-        ]
+
+        try:
+            ttf_pattern_features = pndata__read_new_pattern_columns_list_with_htf(
+                timeframe, pattern
+            )
+        except Exception as e:
+            print(f"    ⚠️ Could not load pattern columns: {e}. Inferring from TTF file")
+            base_features = [
+                'Open', 'High', 'Low', 'Close', 'ao', 'ac', 'mfi'
+            ]
+            mx_targets = [
+                'target', 'fdbb', 'fdbs', 'fdb', 'zlcb', 'zlcs', 'vaoc', 'vaos', 'vaob'
+            ]
+            exclude = set(base_features + mx_targets)
+            ttf_pattern_features = [c for c in ttf_df.columns if c not in exclude]
+        # remove duplicates while preserving order
+        ttf_pattern_features = list(dict.fromkeys(ttf_pattern_features))
         
         # Essential MX targets for profitability analysis
         mx_target_signals = [


### PR DESCRIPTION
## Summary
- remove prototype list of pattern features in unified dataset generator
- read pattern columns from settings with `pndata__read_new_pattern_columns_list_with_htf`
- fall back to inferring pattern columns from TTF data when settings are missing
- log the refinement in a new ledger entry

## Testing
- `pytest -q` *(fails: FileNotFoundError and missing test data)*

------
https://chatgpt.com/codex/tasks/task_e_6845179b2ec0832992b4c61256be1434