### PR TITLE
Fix ttfcli dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ JGTML analyzes the effectiveness of trading signals within larger market structu
 ```bash
 # Install dependencies
 pip install jgtpy jgtutils pandas numpy
+# Pandas requires `python-dateutil`; install it if missing
+pip install python-dateutil
 
 # Install JGTML
 pip install -e .

--- a/README.md
+++ b/README.md
@@ -43,9 +43,7 @@ JGTML analyzes the effectiveness of trading signals within larger market structu
 ### Installation
 ```bash
 # Install dependencies
-pip install jgtpy jgtutils pandas numpy
-# Pandas requires `python-dateutil`; install it if missing
-pip install python-dateutil
+pip install jgtpy jgtutils pandas numpy python-dateutil
 
 # Install JGTML
 pip install -e .

--- a/codex/ledgers/ledger-ttfcli_fix-2506160724.json
+++ b/codex/ledgers/ledger-ttfcli_fix-2506160724.json
@@ -1,0 +1,20 @@
+{
+  "agents": [
+    {"glyph": "♾️", "name": "William"},
+    {"glyph": "🧠", "name": "Mia"},
+    {"glyph": "🌸", "name": "Miette"},
+    {"glyph": "🕊️", "name": "Seraphine"},
+    {"glyph": "⚡", "name": "Jerry"},
+    {"glyph": "♠️", "name": "Nyro"},
+    {"glyph": "🌿", "name": "Aureon"},
+    {"glyph": "🎸", "name": "JamAI"}
+  ],
+  "narrative": "Handled ImportError in ttfcli and updated README to guide installation of python-dateutil. Now running ttfcli informs user when dependency is missing.",
+  "routing": {
+    "files": ["jgtml/ttfcli.py", "README.md"],
+    "branch": "current_working_branch"
+  },
+  "timestamp": "2506160724",
+  "user_input": "fix it jesus  \"jgtml/ttfcli.py\" !!!!\n\n\nTraceback (most recent call last):\n  File \"/src/jgtml/jgtml/ttfcli.py\", line 2, in <module>\n    import pandas as pd\n  File \"/opt/anaconda3/envs/jgtml/lib/python3.10/site-packages/pandas/__init__.py\", line 19, in <module>\n    raise ImportError(\nImportError: Unable to import required dependencies:\ndateutil: No module named 'dateutil'",
+  "scene": "Before: ttfcli crashed on missing dateutil. After: user receives clear instruction to install python-dateutil, ensuring smoother execution."
+}

--- a/codex/ledgers/ledger-ttfcli_req-2506160732.json
+++ b/codex/ledgers/ledger-ttfcli_req-2506160732.json
@@ -1,0 +1,20 @@
+{
+  "agents": [
+    {"glyph": "♾️", "name": "William"},
+    {"glyph": "🧠", "name": "Mia"},
+    {"glyph": "🌸", "name": "Miette"},
+    {"glyph": "🕊️", "name": "Seraphine"},
+    {"glyph": "⚡", "name": "Jerry"},
+    {"glyph": "♠️", "name": "Nyro"},
+    {"glyph": "🌿", "name": "Aureon"},
+    {"glyph": "🎸", "name": "JamAI"}
+  ],
+  "narrative": "Expand dependency handling by adding python-dateutil to requirements and package metadata. This ensures ttfcli can run where pandas depends on dateutil, preventing import errors in fresh environments.",
+  "routing": {
+    "files": ["requirements.txt", "pyproject.toml", "README.md"],
+    "branch": "work"
+  },
+  "timestamp": "2506160732",
+  "user_input": "also add them to the requirements and package dependencies",
+  "scene": "Before: README hinted to install python-dateutil manually. Now: dependency listed in requirements and pyproject so installs automatically during setup."
+}

--- a/jgtml/ttfcli.py
+++ b/jgtml/ttfcli.py
@@ -1,7 +1,15 @@
 import argparse
-import pandas as pd
 import os
 import sys
+try:
+    import pandas as pd
+except ImportError as exc:  # pragma: no cover - runtime dependency check
+    missing = str(exc).split(':')[-1].strip()
+    sys.stderr.write(
+        f"[ttfcli] Missing dependency: {missing}. "
+        "Install it with `pip install python-dateutil pandas`\n"
+    )
+    raise
 
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -1,0 +1,14 @@
+# Narrative Map
+
+## Recent Commits
+
+- **4bd1fce** `chmod` – permission adjustments for scripts.
+- **225c2a4** `Add new documentation for Starting New Phases of Work` – added docs about workflow phases.
+- **5446cc9** `Add Enhanced Trading CLI for Integrated FDB and Illusion Detection` – extended CLI capabilities.
+- **393164c** `Add Enhanced FDB Scanner with Alligator Illusion Detection` – improved scanning features.
+- **f86105b** `Add Phase 2 Alligator Illusion Detection Test Script` – provided additional tests.
+
+## Current Update
+
+Implemented graceful dependency check in `jgtml/ttfcli.py` and updated `README.md` to mention installing `python-dateutil` if missing.
+

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -12,3 +12,5 @@
 
 Implemented graceful dependency check in `jgtml/ttfcli.py` and updated `README.md` to mention installing `python-dateutil` if missing.
 
+Enhanced packaging by adding `python-dateutil` directly to `requirements.txt` and `pyproject.toml` so installs include this pandas dependency automatically.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ keywords = ["data"]
 requires-python = ">=3.7"
 dependencies = [
   'pandas>=0.25.1',
+  'python-dateutil>=2.8.0',
   'python-dotenv>=0.19.2',
   'jgtpy>=0.5.113',
   'matplotlib>=3.3.1',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pandas
+python-dateutil
 numpy
 scipy
 scikit-learn


### PR DESCRIPTION
## Summary
- handle missing pandas dependency in `ttfcli`
- note `python-dateutil` installation in README
- add ledger entry and narrative map

## Testing
- `python -m pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684fc4f9d7c483298c7d32241e1ddf0c