### PR TITLE
Add required data documentation

### DIFF
--- a/alligator_illusion_standalone.py
+++ b/alligator_illusion_standalone.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
-"""
-Standalone Alligator Illusion Detection - Phase 2 Testing
-Minimal dependencies version for testing with real CDS data
+"""Alligator Illusion standalone detector.
+
+This script implements a lightweight version of the Alligator Illusion
+detection logic so it can be executed on its own without the rest of the
+`jgtml` package.  It loads cached CDS data, analyzes the Alligator indicator
+for multiple timeframes, and surfaces contradictory or weak signals.  The
+standalone form is useful for quick experiments or debugging when the full
+environment with `jgtpy` and heavier dependencies is unavailable.
 """
 
 import csv

--- a/codex/ledgers/ledger-alligator-comment-2506162321.json
+++ b/codex/ledgers/ledger-alligator-comment-2506162321.json
@@ -1,0 +1,20 @@
+{
+  "agents": [
+    {"glyph": "♾️", "name": "William"},
+    {"glyph": "🧠", "name": "Mia"},
+    {"glyph": "🌸", "name": "Miette"},
+    {"glyph": "🕊️", "name": "Seraphine"},
+    {"glyph": "⚡", "name": "Jerry"},
+    {"glyph": "♠️", "name": "Nyro"},
+    {"glyph": "🌿", "name": "Aureon"},
+    {"glyph": "🎸", "name": "JamAI"}
+  ],
+  "narrative": "Added explanatory header comment to alligator_illusion_standalone.py clarifying its role as a lightweight standalone detector for quick experimentation.",
+  "routing": {
+    "files": ["alligator_illusion_standalone.py"],
+    "branch": "work"
+  },
+  "timestamp": "2506162321",
+  "user_input": "Add a comment in the code that explains the purpose of alligator_illusion_standalone.py.",
+  "scene": "Before: script had minimal header, leaving purpose unclear. After: clear comment helps future developers understand standalone usage context."
+}

--- a/codex/ledgers/ledger-required-data-2506170002.json
+++ b/codex/ledgers/ledger-required-data-2506170002.json
@@ -1,0 +1,20 @@
+{
+  "agents": [
+    {"glyph": "♾️", "name": "William"},
+    {"glyph": "🧠", "name": "Mia"},
+    {"glyph": "🌸", "name": "Miette"},
+    {"glyph": "🕊️", "name": "Seraphine"},
+    {"glyph": "⚡", "name": "Jerry"},
+    {"glyph": "♠️", "name": "Nyro"},
+    {"glyph": "🌿", "name": "Aureon"},
+    {"glyph": "🎸", "name": "JamAI"}
+  ],
+  "narrative": "Documented the required CSV data format for Alligator Illusion detection. This guidance ensures future integration of mouth/water state ingestion and CLI routing across repositories.",
+  "routing": {
+    "files": ["docs/Required_Alligator_Data.md"],
+    "branch": "work"
+  },
+  "timestamp": "2506170002",
+  "user_input": "produce a document for the required data to make sure it will be implemented down the line",
+  "scene": "Before: data expectations scattered across scripts. After: a single doc clarifies columns and cache layout, smoothing future pipeline setup."
+}

--- a/docs/Required_Alligator_Data.md
+++ b/docs/Required_Alligator_Data.md
@@ -1,0 +1,47 @@
+# Required Data for Alligator Illusion Detection
+
+This document outlines the minimal data requirements for running the Alligator Illusion detection tools contained in the `jgtml` repository. Having these datasets prepared ensures that integration with `jgtpy` and higher level workflows proceeds smoothly.
+
+## CSV Cache Files
+
+The detector expects CSV files in a cache directory (default: `/src/jgtml/cache/fdb_scanners`). Each file name follows the pattern:
+
+```
+<INSTRUMENT>_<TIMEFRAME>_cds_cache.csv
+```
+
+### Mandatory Columns
+
+| Column Name Variants | Description |
+|---------------------|-------------|
+| `alligator_jaw`, `Alligator_Jaw`, `jaw` | Alligator jaw value |
+| `alligator_teeth`, `Alligator_Teeth`, `teeth` | Alligator teeth value |
+| `alligator_lips`, `Alligator_Lips`, `lips` | Alligator lips value |
+| `timestamp` or `Timestamp` | Candle close timestamp |
+
+The standalone scripts look for these columns and accept any of the variants shown.
+
+### Example Directory Layout
+
+```
+cache/
+└── fdb_scanners/
+    ├── EUR-USD_D1_cds_cache.csv
+    ├── EUR-USD_H1_cds_cache.csv
+    └── ...
+```
+
+## Generating Data
+
+Run the FDB scanner to produce cache files. Example:
+
+```bash
+JGT_CACHE=cache fdbscan -i EUR-USD -t H1 --refresh-cache
+```
+
+## Additional Notes
+
+* Data should be refreshed regularly to ensure illusion detection uses recent market information.
+* Ensure numeric values are stored in plain decimal form without thousand separators.
+* The same CSVs can be used with the full `AlligatorIllusionDetector` and the lightweight `alligator_illusion_standalone.py`.
+

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -16,3 +16,5 @@ Enhanced packaging by adding `python-dateutil` directly to `requirements.txt` an
 
 - **caea33f** `fix: handle missing illusion count` – improved resilience of enhanced FDB scanner and added CLI entrypoint.
 Updated CLI offerings with 'enhancedfdbscan' command and improved error handling.
+- **WORKING** `comment: clarify standalone script purpose` – inserted header comment to explain `alligator_illusion_standalone.py` for future reference.
+- **WORKING** `docs: list required alligator data` – documented required dataset for illusion detection.


### PR DESCRIPTION
## Summary
- outline the CSV cache files needed for Alligator Illusion detection
- note mandatory columns and example layout
- record ledger entry with glyph agents
- update narrative map with commit note

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850a67a458883299a211863f2ac1028