### PR TITLE
Fix IDSCLI flag usage in jgtapp

### DIFF
--- a/codex/ledgers/ledger-idscli-arg-fix-2506181531.json
+++ b/codex/ledgers/ledger-idscli-arg-fix-2506181531.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506181531",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Corrected IDS refresh logic to prevent invalid parameter combination. IDs refresh now uses -uf/-nf for full store flag and --fresh/-old for data freshness, eliminating argument clash.",
+  "files": ["jgtml/jgtapp.py"],
+  "branches": "main",
+  "session": "shell",
+  "purpose": "ensure stable fdbscan workflow",
+  "user_input": "python -m jgtml.jgtapp fdbscan --instrument USD-CAD --timeframe D1\n... idscli: error: argument -old/--notfresh: not allowed with argument -new/--fresh",
+  "scene": "Future runs of jgtapp ids will refresh data without conflicting flags, enabling FDB scans to proceed." ,
+  "glyph": "🌿⚙️🎶"
+}

--- a/jgtml/jgtapp.py
+++ b/jgtml/jgtapp.py
@@ -244,11 +244,17 @@ def fxmvstop(tradeid,stop,flag_pips=False, demo=False,args=None):
     #@STCIssue pass the error code to the caller context.  ex. fxmvstop is ran directly from the CLI, the error code should be passed by exiting the process with the error code, else if used by fxmvstopgator, the error code should be passed to the caller context in a raised exception.
     #look at the args command to guess the context
 
-def ids(instrument, timeframe,use_full=False,use_fresh=True):
+def ids(instrument, timeframe, use_full=False, use_fresh=True):
   """Refresh the IDS data (indicator Data Service)."""
-  use_fresh_arg = '-old' if not use_fresh else '--fresh'
-  use_full_arg = '--full' if use_full else '-new'
-  subprocess.run([IDSCLI_PROG_NAME, '-i', instrument, '-t', timeframe, use_full_arg, use_fresh_arg], check=True)
+  use_fresh_arg = '--fresh' if use_fresh else '-old'
+  use_full_arg = '-uf' if use_full else '-nf'
+  subprocess.run([
+      IDSCLI_PROG_NAME,
+      '-i', instrument,
+      '-t', timeframe,
+      use_full_arg,
+      use_fresh_arg,
+  ], check=True)
 
 """
 fxmvstopgator -tid 68773276  --demo -i AUD/NZD -t H4 --lips

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -16,3 +16,4 @@ Enhanced packaging by adding `python-dateutil` directly to `requirements.txt` an
 
 - **caea33f** `fix: handle missing illusion count` – improved resilience of enhanced FDB scanner and added CLI entrypoint.
 Updated CLI offerings with 'enhancedfdbscan' command and improved error handling.
+- Fixed idscli call to avoid conflicting -new/-old flags.


### PR DESCRIPTION
## Summary
- update `ids()` to correctly set `-uf/-nf` and `--fresh/-old`
- document fix in `narrative-map.md`
- log ledger entry for this change

## Testing
- `pytest -q` *(fails: FileNotFoundError for test CSV)*

------
https://chatgpt.com/codex/tasks/task_e_6852da8b353083299dd821cf7a334cb7