### PR TITLE
Fix enhancedtradingcli import path

### DIFF
--- a/codex/ledgers/ledger-enhancedtradingcli-importfix-2506182222.json
+++ b/codex/ledgers/ledger-enhancedtradingcli-importfix-2506182222.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506182222",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Refined path handling within enhanced_trading_cli to prevent ModuleNotFoundError when running the installed enhancedtradingcli entry point.",
+  "files": ["jgtml/enhanced_trading_cli.py"],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "fix CLI import issue",
+  "user_input": "Traceback (most recent call last): ... ModuleNotFoundError: No module named 'jgtml'\n\"enhancedtradingcli\" needs fixing of import",
+  "scene": "Future runs of enhancedtradingcli locate the package correctly, enabling full trading workflow.",
+  "glyph": "🐍✨"
+}

--- a/jgtml/enhanced_trading_cli.py
+++ b/jgtml/enhanced_trading_cli.py
@@ -17,8 +17,10 @@ from pathlib import Path
 import argparse
 from datetime import datetime
 
-# Add jgtml to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'jgtml'))
+# Ensure the package directory is on the import path
+package_dir = Path(__file__).resolve().parent
+if str(package_dir) not in sys.path:
+    sys.path.insert(0, str(package_dir))
 
 def run_enhanced_fdb_scan(instrument, timeframes, options):
     """Run the enhanced FDB scanner with illusion detection"""

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -37,3 +37,4 @@ Updated CLI offerings with 'enhancedfdbscan' command and improved error handling
 
 ### Branch: codex/fix-conflict-between--new-and--old-arguments-2025-06-18-16-30-36
 - Logged merge resolution in `ledger-merge-main-resolution-2506182049.json`
+- **5a3b4b9** `fix: ensure enhancedtradingcli import path` – updated path handling for CLI.


### PR DESCRIPTION
## Summary
- ensure the package directory is added to `sys.path` within `enhanced_trading_cli.py`
- document the fix in a new ledger
- update `narrative-map.md`

## Testing
- `pytest -q` *(fails: FileNotFoundError: tests data)*

------
https://chatgpt.com/codex/tasks/task_e_68533b32c88483298a59eb8129619c1d