### PR TITLE
Add programmatic pattern generation helpers

### DIFF
--- a/codex/ledgers/ledger-ttfmlf-helpers-2506182234.json
+++ b/codex/ledgers/ledger-ttfmlf-helpers-2506182234.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506182234",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Introduced generate_ttf_for_pattern and generate_mlf_for_pattern to allow programmatic creation of TTF and MLF datasets from JTC without shell calls.",
+  "files": ["jgtml/ttfcli.py", "jgtml/mlfcli.py"],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "enable automated pattern generation inside jtc",
+  "user_input": "(jgtml) jgi@hu:/src/jgtml$ bash scripts/BATCH_mlf_jgtml_250606_to_observe.sh ... ImportError: cannot import name 'generate_ttf_for_pattern' from 'ttfcli'",
+  "scene": "Future jgtmlcli runs auto-create missing datasets for patterns, improving workflow resilience.",
+  "glyph": "🌀📈"
+}

--- a/jgtml/mlfcli.py
+++ b/jgtml/mlfcli.py
@@ -52,8 +52,38 @@ def create_app_arguments()->argparse.Namespace:
   args:argparse.Namespace=jgtcommon.parse_args(parser)
   
   args =check_arguments(args)
-  
+
   return args
+
+
+def generate_mlf_for_pattern(
+    instrument,
+    timeframe,
+    patternname="ttf",
+    lag_period=1,
+    total_lagging_periods=5,
+    use_full=True,
+    use_fresh=False,
+    columns_to_keep=None,
+    columns_to_drop=None,
+    drop_bid_ask=False,
+    args=None,
+):
+    """Convenience wrapper around realityhelper.generate_mlf_feature_pattern."""
+    return realityhelper.generate_mlf_feature_pattern(
+        instrument,
+        timeframe,
+        lag_period=lag_period,
+        total_lagging_periods=total_lagging_periods,
+        dropna=True,
+        use_full=use_full,
+        columns_to_keep=columns_to_keep,
+        columns_to_drop=columns_to_drop,
+        drop_bid_ask=drop_bid_ask,
+        force_refresh=use_fresh,
+        pn=patternname,
+        args=args,
+    )
   
 
 

--- a/jgtml/ttfcli.py
+++ b/jgtml/ttfcli.py
@@ -42,8 +42,24 @@ def _parse_args():
     args = jgtcommon.parse_args(parser)
     
     args =check_arguments(args)
-    
+
     return args
+
+
+def generate_ttf_for_pattern(instrument, timeframe, patternname="ttf", use_full=True, use_fresh=False, quotescount=-1, columns_list_from_higher_tf=None, args=None):
+    """Programmatic helper mirroring CLI behavior for JTC integrations."""
+    pseudo_force_read_flag = True if not use_fresh else False
+    return create_ttf_csv(
+        instrument,
+        timeframe,
+        use_full if use_full else False,
+        True if use_fresh else False,
+        quotescount,
+        pseudo_force_read_flag,
+        columns_list_from_higher_tf=columns_list_from_higher_tf,
+        pn=patternname,
+        args=args,
+    )
 
 
 def main():

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -38,3 +38,6 @@ Updated CLI offerings with 'enhancedfdbscan' command and improved error handling
 ### Branch: codex/fix-conflict-between--new-and--old-arguments-2025-06-18-16-30-36
 - Logged merge resolution in `ledger-merge-main-resolution-2506182049.json`
 - **5a3b4b9** `fix: ensure enhancedtradingcli import path` – updated path handling for CLI.
+
+- **9d5da56** `feat: expose pattern generation helpers` – added generate_ttf_for_pattern and generate_mlf_for_pattern for internal use.
+- **c862081** `chore: log ledger for ttf/mlf helper addition` – recorded changes supporting automated dataset generation.


### PR DESCRIPTION
## Summary
- expose `generate_ttf_for_pattern` in `ttfcli`
- expose `generate_mlf_for_pattern` in `mlfcli`
- document the change in the narrative map
- log a ledger entry for the helper addition

## Testing
- `pytest -q` *(fails: FileNotFoundError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68533e0a03fc832988092dc8769e9a13