### PR TITLE
Fix JGTApp import in refresh script

### DIFF
--- a/.jgt/real_data_refresh.py
+++ b/.jgt/real_data_refresh.py
@@ -1,27 +1,26 @@
 #!/usr/bin/env python3
-"""
-Real Data Refresh using JGTApp CDS Function
-Uses the actual jgtapp.cds() function that generates proper CDS cache
-"""
+"""Real Data Refresh using JGTApp CDS Function
+Uses the actual jgtapp.cds() function that generates proper CDS cache"""
 
 import sys
 import os
 sys.path.append('/src/jgtml')
 
+
 def refresh_with_jgtapp():
     """Use the real jgtapp.cds() function to refresh data properly"""
     try:
-        from jgtml.jgtml.jgtapp import cds
-        
+        from jgtml.jgtapp import cds
+
         instruments = ['EUR/USD', 'GBP/USD', 'XAU/USD']  # Note: using / format for jgtapp
         timeframes = ['H4', 'H1', 'm15']
-        
+
         print("🚀 REAL DATA REFRESH - Using JGTApp CDS")
         print("=" * 60)
-        
+
         for instrument in instruments:
             print(f"🔄 Refreshing {instrument}...")
-            
+
             for tf in timeframes:
                 try:
                     print(f"  📊 Generating {instrument} {tf} CDS data...")
@@ -29,14 +28,15 @@ def refresh_with_jgtapp():
                     print(f"  ✅ {instrument} {tf} CDS data generated")
                 except Exception as e:
                     print(f"  ❌ {instrument} {tf} failed: {e}")
-        
+
         print("=" * 60)
         print("✅ Real data refresh completed using jgtapp.cds()")
         return True
-        
+
     except Exception as e:
         print(f"❌ Real data refresh failed: {e}")
         return False
 
+
 if __name__ == "__main__":
-    refresh_with_jgtapp() 
+    refresh_with_jgtapp()

--- a/codex/ledgers/ledger-importfix-realdatarefresh-2506182254.json
+++ b/codex/ledgers/ledger-importfix-realdatarefresh-2506182254.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506182254",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Adjusted real_data_refresh to use correct jgtapp import path so automated trading scripts can refresh CDS data without ModuleNotFoundError.",
+  "files": [".jgt/real_data_refresh.py"],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "fix import path in refresh helper",
+  "user_input": "WORK ON\n\n❌ Real data refresh failed: No module named 'jgtml.jgtml'",
+  "scene": "Future runs of jgt_simple_trader.sh will load jgtapp properly and refresh real data before trading cycles.",
+  "glyph": "🌿🔧"
+}

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -1,6 +1,8 @@
 # Narrative Map
 
 ## Recent Commits
+- **a81b638** `chore: ledger for refresh import fix`
+- **bd8635e** `fix: correct jgtapp import for real refresh`
 
 - **4bd1fce** `chmod` – permission adjustments for scripts.
 - **225c2a4** `Add new documentation for Starting New Phases of Work` – added docs about workflow phases.


### PR DESCRIPTION
## Summary
- fix path in `.jgt/real_data_refresh.py` so jgt_simple_trader can refresh data
- record the change in ledger
- update narrative map

## Testing
- `pytest -q` *(fails: FileNotFoundError: AUD-CAD_H1_cds_cache_24082107.csv)*

------
https://chatgpt.com/codex/tasks/task_e_685342d98d1c8329b17692f233c1bdeb