### PR TITLE
Add dataset automation scripts and guidecli

### DIFF
--- a/codex/ledgers/ledger-automation-2506211710.json
+++ b/codex/ledgers/ledger-automation-2506211710.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506211710",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Introduced guidecli_jgtml for agent docs and a parallel script to generate TTF/MLF data from stored CDS files. Version bumped to 0.0.342 and narrative map updated.",
+  "files": ["jgtml/guidecli_jgtml.py", "scripts/generate_ttf_mlf_d1.sh", "jgtml/guide_for_llm_agents/index.md", "jgtml/guide_for_llm_agents/automation.md", "narrative-map.md", "jgtml/__init__.py", "pyproject.toml", "package.json"],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Automate dataset preparation and document usage for issue #42",
+  "user_input": "in ./data/full/cds you have what you need to generate the TTF and MLF data.  look at *.sh in the root to make sure you use that data and I want you to think of automating the generation of those various patterns that are possible for preparing the machine learning data framework.  Generate new bash script for yourself so later on you would be capable to generate these data.  Think of processing in parallel for efficiency and focus on D1 timeframes with the required amount of instruments to look for being capable to do your job.   Make sure this intentions is reflected into a section of the narrative-map.md\n\nif you need to understand the data use : guidecli_jgtpy --help\n\nthat might be relevant to start creating ./jgtml/guidecli_jgtml.py where you will mimic what you learn from that package \"jgtpy\" that generated the data you found in ./data/full/cds\n\nWe work on issue #42 so use  Workspace.jgwill.jgtpy:42 for your work",
+  "scene": "Automated dataset scripts enable future ML data refresh cycles while agents access quick docs through guidecli_jgtml.",
+  "glyph": "⚙️📖"
+}

--- a/codex/ledgers/ledger-automation-2506211908.json
+++ b/codex/ledgers/ledger-automation-2506211908.json
@@ -1,0 +1,12 @@
+{
+  "timestamp": "2506211908",
+  "agents": ["🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Added dataset presence check to automation script and documented it in the narrative map.",
+  "files": ["scripts/generate_ttf_mlf_d1.sh", "narrative-map.md"],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Ensure offline generation script fails gracefully for issue #42",
+  "user_input": "keep advancing, no need to connect you need to focus on what is offered by this package and in ./data you have what is generates",
+  "scene": "Script stops with clear message when no CDS data exists, avoiding ForexConnect errors.",
+  "glyph": "⚙️📖"
+}

--- a/jgtml/__init__.py
+++ b/jgtml/__init__.py
@@ -1,5 +1,5 @@
 # jgtml
-version='0.0.341'
+version='0.0.342'
 import sys
 import os
 

--- a/jgtml/guide_for_llm_agents/automation.md
+++ b/jgtml/guide_for_llm_agents/automation.md
@@ -1,0 +1,7 @@
+# Automation Overview
+
+The `scripts/generate_ttf_mlf_d1.sh` script automates generation of TTF and MLF files from existing CDS data. It runs pattern creation in parallel on the D1 timeframe for a default set of instruments.
+
+```bash
+./scripts/generate_ttf_mlf_d1.sh
+```

--- a/jgtml/guide_for_llm_agents/index.md
+++ b/jgtml/guide_for_llm_agents/index.md
@@ -1,0 +1,4 @@
+# JGTML Agent Guide
+
+This guide provides small snippets for LLM-based agents working with the `jgtml` package.
+Use `guidecli_jgtml --list` to see available topics.

--- a/jgtml/guidecli_jgtml.py
+++ b/jgtml/guidecli_jgtml.py
@@ -1,0 +1,47 @@
+"""CLI to display small documentation snippets for LLM agents using jgtml."""
+import argparse
+import importlib.resources as pkg_resources
+from pathlib import Path
+
+PACKAGE = 'jgtml'
+DOC_PATH = 'guide_for_llm_agents'
+
+def _doc_dir() -> Path:
+    return pkg_resources.files(PACKAGE) / DOC_PATH
+
+def list_sections():
+    return [p.stem for p in _doc_dir().iterdir() if p.suffix == '.md']
+
+def read_section(name: str) -> str:
+    path = _doc_dir() / f"{name}.md"
+    if path.is_file():
+        return path.read_text()
+    raise FileNotFoundError(f'Section {name} not found')
+
+def main():
+    parser = argparse.ArgumentParser(description='JGTML documentation for LLM agents')
+    parser.add_argument('--list', action='store_true', help='List available sections')
+    parser.add_argument('--section', help='Display a specific section')
+    parser.add_argument('--all', action='store_true', help='Display all sections')
+    args = parser.parse_args()
+
+    if args.list:
+        for sec in list_sections():
+            print(sec)
+        return
+
+    if args.all:
+        for sec in list_sections():
+            print(f"# {sec}\n")
+            print(read_section(sec))
+            print()
+        return
+
+    if args.section:
+        print(read_section(args.section))
+        return
+
+    parser.print_help()
+
+if __name__ == '__main__':
+    main()

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -18,6 +18,13 @@ Enhanced packaging by adding `python-dateutil` directly to `requirements.txt` an
 Updated CLI offerings with 'enhancedfdbscan' command and improved error handling.
 - Fixed idscli call to avoid conflicting -new/-old flags.
 
+### Issue #42 Automation Initiative
+Introduced new automation tools for dataset preparation:
+- `scripts/generate_ttf_mlf_d1.sh` runs TTF and MLF generation in parallel for D1 timeframe instruments.
+- `guidecli_jgtml` exposes short documentation sections from `jgtml/guide_for_llm_agents`.
+- Script now checks for local CDS files before running and aborts with a helpful
+  message if none are found.
+
 ### branch: codex/fix-conflict-between--new-and--old-arguments-2025-06-18-16-30-36
 - Updated cdscli invocation to pass -uf/-nf flags and validated wrappers, documenting fixes in CHANGELOG. Merged main at version 0.0.333 to integrate trading orchestrator.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jgtml",
-  "version": "0.0.341",
+  "version": "0.0.342",
   "description": "JGTML",
   "main": "index.js",
   "directories": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jgtml"
-version = "0.0.341"
+version = "0.0.342"
 authors = [
   { name="Guillaume Isabelle", email="jgi@jgwill.com" },
 ]
@@ -93,4 +93,5 @@ jgtunified_discovery_dataset_generator="jgtml.unified_discovery_dataset_generato
 enhancedfdbscan="jgtml.enhanced_fdb_scanner_with_illusion_detection:main"
 enhancedtradingcli="jgtml.enhanced_trading_cli:main"
 automatedfdbtrading="jgtml.automated_fdb_trading_system:main"
+guidecli_jgtml="jgtml.guidecli_jgtml:main"
 

--- a/scripts/generate_ttf_mlf_d1.sh
+++ b/scripts/generate_ttf_mlf_d1.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# generate_ttf_mlf_d1.sh - create TTF and MLF files from CDS for D1 timeframe
+set -euo pipefail
+
+TIMEFRAMES="D1"
+INSTRUMENTS="EUR/USD USD/CAD SPX500 AUD/USD AUD/CAD GBP/USD"
+PATTERNS="mfi mz zonesq"
+MAX_PARALLEL=${MAX_PARALLEL:-4}
+
+source .env 2>/dev/null || true
+export JGTPY_DATA_FULL=${JGTPY_DATA_FULL:-$(pwd)/data/full}
+DATA_CHECK_GLOB="$JGTPY_DATA_FULL/cds/*.csv"
+
+if ! ls $DATA_CHECK_GLOB 1> /dev/null 2>&1; then
+    echo "No CDS data found in $JGTPY_DATA_FULL. Place CSV files under cds/ and rerun." >&2
+    exit 1
+fi
+
+queue(){
+    while (( $(jobs -r | wc -l) >= MAX_PARALLEL )); do
+        sleep 0.5
+    done
+    "$@" &
+}
+
+for inst in $INSTRUMENTS; do
+    for pat in $PATTERNS; do
+        queue ttfcli -i "$inst" -t D1 -pn "$pat" --full -old
+        queue mlfcli -i "$inst" -t D1 -pn "$pat" --full -old
+    done
+done
+
+wait
+printf '\nGeneration complete.\n'


### PR DESCRIPTION
## Summary
- add `generate_ttf_mlf_d1.sh` for parallel TTF/MLF generation
- provide `guidecli_jgtml` tool and doc snippets
- bump version to 0.0.342 and register entry point
- update narrative map with automation initiative
- record automation ledger
- add dataset presence check for automation script

## Testing
- `make test` *(fails: coverage not installed)*
- `pytest -q` *(fails: missing test data)*
- `bash scripts/generate_ttf_mlf_d1.sh` *(fails: No CDS data found)*

------
https://chatgpt.com/codex/tasks/task_e_6856e61a8d388329b25e36d1b71867b6