### PR TITLE
Add pattern details to TTF docs

### DIFF
--- a/codex/ledgers/ledger-dataset-clarify-2506251909.json
+++ b/codex/ledgers/ledger-dataset-clarify-2506251909.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2506251909",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Clarified dataset derivation flow and linked base IDS/CDS columns. Added cross references so docs reflect how TTF, MLF, and MX build upon each other.",
+  "files": [
+    "docs/index_purpose_data_columns.md",
+    "docs/TTF_purpose.md",
+    "docs/MLF_purpose.md",
+    "docs/MX_purpose.md",
+    "docs/TTF_data_columns.md",
+    "docs/MLF_data_columns.md",
+    "docs/MX_data_columns.md"
+  ],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Address feedback to highlight differences among datasets and show dependency on IDS/CDS columns",
+  "user_input": "Please address any inline comments on the diff, as well as any additional instructions below. These are from jgtpy, they might going to help you not being too redundant and also focus on what the TTF / MLF / MX data has that differentiate from the one they derived bellow.",
+  "scene": "Future developers trace dataset lineage from raw IDS to profit-target MX files with ease thanks to unified docs.",
+  "glyph": "📖🧠"
+}

--- a/codex/ledgers/ledger-pattern-docs-2506251614.json
+++ b/codex/ledgers/ledger-pattern-docs-2506251614.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2506251614",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Documented dataset patterns and target signal locations to guide training workflow.",
+  "files": [
+    "docs/index_purpose_data_columns.md",
+    "docs/TTF_purpose.md",
+    "docs/MLF_purpose.md",
+    "docs/MX_purpose.md",
+    "docs/TTF_data_columns.md",
+    "docs/MLF_data_columns.md",
+    "docs/MX_data_columns.md"
+  ],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Clarify how patterns relate to dataset columns and where signals reside",
+  "user_input": "if you look in $HOME/.jgt/settings.json you will find a property \"patterns\" that determine names and columns it includes.\n\nafter you have done that , keep observing what you have in ./data/full/targets/mx or  ./data/full/mx/targets you should find potential signals \"fdbb\" and \"fdbs\" with their corresponding  profit or loss in the \"target\" column.  you should also be capable to find the corresponding dataset under  ./data/full/ttf|mlf|cds \n\nwork on all you find related in : docs/index_purpose_data_columns.md\n\n* In development, data is in ./data/full/ttf ./data/full/mlf ./data/targets/mx",
+  "scene": "Future analysts navigate data directories confidently, relying on the updated docs to locate features and profit metrics.",
+  "glyph": "📖🎸"
+}

--- a/codex/ledgers/ledger-pattern-docs-2506251814.json
+++ b/codex/ledgers/ledger-pattern-docs-2506251814.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2506251814",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Expanded dataset documentation with clearer pattern descriptions and target signal notes.",
+  "files": [
+    "docs/index_purpose_data_columns.md",
+    "docs/TTF_purpose.md",
+    "docs/MLF_purpose.md",
+    "docs/MX_purpose.md",
+    "docs/TTF_data_columns.md",
+    "docs/MLF_data_columns.md",
+    "docs/MX_data_columns.md"
+  ],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Complete user request to document dataset patterns and target signals with proper structure.",
+  "user_input": "if you look in $HOME/.jgt/settings.json you will find a property \"patterns\" that determine names and columns it includes.\n\nafter you have done that , keep observing what you have in ./data/full/targets/mx or  ./data/full/mx/targets you should find potential signals \"fdbb\" and \"fdbs\" with their corresponding  profit or loss in the \"target\" column.  you should also be capable to find the corresponding dataset under  ./data/full/ttf|mlf|cds \n\nwork on all you find related in : docs/index_purpose_data_columns.md\n\n* In development, data is in ./data/full/ttf ./data/full/mlf ./data/targets/mx",
+  "scene": "Future analysts quickly trace features to targets using the tidy docs.",
+  "glyph": "📖🎸"
+}

--- a/codex/ledgers/ledger-ttf-pattern-sections-2506251926.json
+++ b/codex/ledgers/ledger-ttf-pattern-sections-2506251926.json
@@ -1,0 +1,15 @@
+{
+  "timestamp": "2506251926",
+  "agents": ["♾️ William", "🧠 Mia", "🌸 Miette", "🎸 JamAI"],
+  "narrative": "Expanded TTF_data_columns with individual sections for each pattern from settings.json and cross-referenced this list from the index doc.",
+  "files": [
+    "docs/TTF_data_columns.md",
+    "docs/index_purpose_data_columns.md"
+  ],
+  "branches": "work",
+  "session": "shell",
+  "purpose": "Document pattern columns so developers can locate features by name and dataset.",
+  "user_input": "That is getting better, what about you read the $HOME/.jgt/settings.json patterns and document each of them in their own sections of the TTF_data_columns.md make sure to refer to what I gave you before for naming the columns etc.",
+  "scene": "Future analysts read TTF documentation to understand which settings pattern produced each column set.",
+  "glyph": "📖🧠"
+}

--- a/docs/MLF_data_columns.md
+++ b/docs/MLF_data_columns.md
@@ -1,5 +1,9 @@
-# TODO: document the columns of MLF with definition of patterns, lagging and the fact that they derived from TTF
+# MLF Data Columns
 
+MLF datasets expand upon the TTF columns by adding a wide array of lagged features. For each pattern column, multiple lag versions (e.g., `_lag_1`, `_lag_2`, ...) are generated along with cross-timeframe values such as `_D1`, `_W1`, and `_M1`.
 
+The base feature definitions originate from the IDS/CDS stages documented in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
 
+Use these files when training models that require temporal context.
 
+MLF CSV files live in `./data/full/mlf` and follow the naming scheme `[instrument]_[timeframe]_[pattern].csv`. They are produced for each pattern listed in `settings.json` and contain hundreds of columns capturing lags across bars and higher timeframes.

--- a/docs/MLF_purpose.md
+++ b/docs/MLF_purpose.md
@@ -1,0 +1,9 @@
+# Purpose of MLF Data
+
+**Meta Lag Features (MLF)** datasets extend TTF by generating multiple lagged versions of each pattern column. They allow the models to consider historical context across several bars and timeframes.
+
+They rely on the same core indicators defined in the IDS/CDS stages documented in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
+
+MLF files are produced for each pattern defined in `settings.json` and are stored in `./data/full/mlf`.
+
+Their lag columns enable models to learn how earlier bars influence later outcomes. The names include the pattern (e.g., `_mfi.csv`) so you can quickly relate them back to the settings file.

--- a/docs/MX_data_columns.md
+++ b/docs/MX_data_columns.md
@@ -1,6 +1,12 @@
-# TODO: document the columns of MX with definition of how they are an attempt to build profit/losses from signals (fdbb and fdbs) with a target variable.  Identify how it relates to TTF and MLF data and their various patterns.  Mostly how they might be recomposed using the TTF or/and MLF data to find which combination of patterns/lagging features the most profitable (or lost perspective).
+# MX Data Columns
 
+MX files include the FDB signals and a `target` column that measures the profit or loss associated with each signal occurrence. Typical columns are:
 
+- `fdbb`, `fdbs` – buy and sell fractal divergent bar signals
+- `target` – numeric outcome for the associated trade
 
+MX datasets may also replicate a subset of TTF or MLF features for analysis.
 
+These feature definitions trace back to the IDS/CDS column lists in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
 
+MX target files reside under `./data/full/targets/mx` or sometimes `./data/full/mx/targets`. They often share the same base name as the originating TTF dataset and include enough feature columns to evaluate signal quality.

--- a/docs/MX_purpose.md
+++ b/docs/MX_purpose.md
@@ -1,6 +1,9 @@
-# TODO: document alongside the columns of MX with definition from [MX_data_columns.md](MX_data_columns.md) of how they are an attempt to build profit/losses from signals (fdbb and fdbs) with a target variable.  Identify how it relates to TTF and MLF data and their various patterns.  Mostly how they might be recomposed using the TTF or/and MLF data to find which combination of patterns/lagging features the most profitable (or lost perspective).
+# Purpose of MX Data
 
+The **MX** datasets capture experimental profit and loss calculations. They combine FDB buy (`fdbb`) and FDB sell (`fdbs`) signals with a resulting `target` column representing the outcome of each trade opportunity.
 
+MX rows still reference the same indicators listed in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md), but pair them with realized or simulated profit values.
 
+These files are derived from TTF or MLF features and live in `./data/targets/mx` or `./data/full/mx/targets` depending on the environment.
 
-
+The goal is to evaluate how reliably the fractal signals translate into profit. Models can train directly on these rows to predict the `target` value.

--- a/docs/TTF_data_columns.md
+++ b/docs/TTF_data_columns.md
@@ -1,2 +1,61 @@
-# TODO: document the columns of TTF with definition of patterns
+# TTF Data Columns
 
+TTF files contain the core trading features derived from CDS. In addition to the raw price and alligator columns, each file includes the pattern columns defined for the `ttf` pattern.
+
+The underlying IDS and CDS column definitions are listed in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
+
+Common columns include:
+
+- `High`, `Low` – bar price extremes
+- `ao`, `ac` – oscillator values
+- `jaw`, `teeth`, `lips` – alligator averages
+- `fh`, `fl` – fractal highs and lows
+- `fdbb`, `fdbs` – fractal divergent bar signals
+- `zlcB`, `zlcS` – zero line cross signals
+- `mfi_sig`, `zone_sig` – pattern columns from `settings.json`
+
+TTF CSV files are named like `AUD-CAD_H4_mfi.csv` or `AUD-CAD_H4_aoac.csv` and reside under `./data/full/ttf` (or `./data/current/ttf` when working with the latest slice).  The pattern name appears in the filename and a companion `*_columns.csv` file lists the exact columns present.  These files form the base feature set used to generate MLF and MX datasets.
+
+## Pattern-specific columns
+
+The `patterns` block of `$HOME/.jgt/settings.json` defines which columns belong to each feature pattern.  When generating a TTF dataset for a given pattern, these columns are included in addition to the common IDS/CDS columns above.
+
+### `mz`
+
+- `mfi_str`
+- `zcol`
+
+### `mfi`
+
+- `mfi_sq`
+- `mfi_green`
+- `mfi_fade`
+- `mfi_fake`
+
+### `mfizone`
+
+- `mfi_sq`
+- `mfi_green`
+- `mfi_fade`
+- `mfi_fake`
+- `zone_sig`
+
+### `zonesq`
+
+- `zone_sig`
+- `mfi_sq`
+
+### `aoabz`
+
+- `aoaz`
+- `aobz`
+
+### `aoac`
+
+- `ao`
+- `ac`
+
+### `ttf`
+
+- `mfi_sig`
+- `zone_sig`

--- a/docs/TTF_purpose.md
+++ b/docs/TTF_purpose.md
@@ -1,0 +1,9 @@
+# Purpose of TTF Data
+
+The **Transformed Trading Features (TTF)** files contain the core pattern columns extracted from CDS data. TTF datasets are created using the `ttf` pattern defined in `$HOME/.jgt/settings.json`, which currently includes the `mfi_sig` and `zone_sig` columns.
+
+TTF builds directly on the CDS outputs described in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
+
+These files provide the minimal feature set used for further lagging and signal generation. They live under `./data/full/ttf` (or `data/current/ttf` for the latest slice).
+
+Each TTF file typically mirrors the instrument and timeframe of its source CDS file (e.g., `AUD-CAD_H4_ttf.csv`). These datasets act as the bridge between raw market data and the more expansive MLF and MX series.

--- a/docs/index_purpose_data_columns.md
+++ b/docs/index_purpose_data_columns.md
@@ -1,28 +1,59 @@
-Add initial documentation files for MLF, MX, and TTF data columns and purposes with TODO notes for future elaboration on patterns and relationships.
+# Overview of Dataset Purpose and Columns
 
+This page explains how the dataset files are organized and how the pattern settings in `$HOME/.jgt/settings.json` influence the columns that appear.
 
-#42
+## Dataset flow
 
+1. **IDS** – Indicator Data Service. Creates the base indicator columns listed in [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md).
+2. **CDS** – Chaos Data Service. Adds advanced columns such as those in the *CDS Columns* section of the same document.
+3. **TTF** – Transformed Trading Features. Selects a subset of CDS columns according to the `ttf` pattern.
+4. **MLF** – Meta Lag Features. Generates lagged versions of the TTF columns for each pattern.
+5. **MX** – Target datasets combining FDB signals with a `target` profit value.
 
-@stcgoal I scaffolded what I want this documentation to contain for creating clarity for the steps of making models that will learn from all that.
-@ STCIssue Redundant repetition of my Intent with LLM when prompting and also no centralized place where to talk about columns patterns
+## Pattern definitions
 
+The `patterns` block of `settings.json` lists the columns generated for each pattern.
 
-* In development, data is in ./data/full/ttf ./data/full/mlf ./data/targets/mx
+| Pattern | Columns |
+| --- | --- |
+| `mz` | `mfi_str`, `zcol` |
+| `mfi` | `mfi_sq`, `mfi_green`, `mfi_fade`, `mfi_fake` |
+| `mfizone` | `mfi_sq`, `mfi_green`, `mfi_fade`, `mfi_fake`, `zone_sig` |
+| `zonesq` | `zone_sig`, `mfi_sq` |
+| `aoabz` | `aoaz`, `aobz` |
+| `aoac` | `ao`, `ac` |
+| `ttf` | `mfi_sig`, `zone_sig` |
 
+These patterns drive which feature columns appear in the TTF and MLF datasets. A detailed list of their columns is provided in [TTF_data_columns.md](TTF_data_columns.md).
 
-------
-SEE:
--------
+## Dataset locations
 
-[TTF_purpose.md](TTF_purpose.md)  
-[TTF_data_columns.md](TTF_data_columns.md)  
+- **`./data/full/ttf`** – Transformed Trading Features generated from CDS using the `ttf` pattern. These hold the base columns for further lagging.
+- **`./data/full/mlf`** – Meta Lag Features derived from TTF. File names end in `[pattern].csv` and contain dozens of lagged versions of each pattern column.
+- **`./data/full/mx/targets`** or **`./data/full/targets/mx`** – Target datasets. Each row records `fdbb` or `fdbs` signals along with a resulting `target` value representing profit or loss.
+- **`./data/current/cds`** – Raw CDS files used to build the above datasets.
 
+All of these datasets ultimately stem from the CDS data produced by jgtpy.
 
-[MLF_purpose.md](MLF_purpose.md)  
-[MLF_data_columns.md](MLF_data_columns.md)  
+## MX targets and signals
 
+Within the MX target files you will see:
 
-[MX_purpose.md](MX_purpose.md)  
-[MX_data_columns.md](MX_data_columns.md)  
+- `fdbb`, `fdbs` – buy and sell fractal divergent bar signals.
+- `target` – numeric profit or loss for that signal.
+- Optionally additional TTF or MLF columns for context.
 
+These metrics drive supervised learning for profit prediction.
+
+---
+
+See the individual documents for each dataset:
+
+- [MFI_and_other_signals_indicators__250609.md](MFI_and_other_signals_indicators__250609.md) – base IDS and CDS column lists
+
+- [TTF_purpose.md](TTF_purpose.md)
+- [TTF_data_columns.md](TTF_data_columns.md)
+- [MLF_purpose.md](MLF_purpose.md)
+- [MLF_data_columns.md](MLF_data_columns.md)
+- [MX_purpose.md](MX_purpose.md)
+- [MX_data_columns.md](MX_data_columns.md)

--- a/narrative-map.md
+++ b/narrative-map.md
@@ -49,3 +49,7 @@ Updated CLI offerings with 'enhancedfdbscan' command and improved error handling
 - **54f54f1** fix: skip zcol int conversion
 - **e99aa97** fix: generate ttf offline when missing
 - **5cdf5ba** extend mfi_str/zcol exclusion
+- **8f49d78** docs: clarify dataset patterns and target layout
+- **2a0ee97** docs: expand dataset documentation
+- **aa477d7** docs: expand dataset lineage
+- **981d1e2** `docs: detail pattern columns`


### PR DESCRIPTION
## Summary
- expand `TTF_data_columns.md` with sections for each pattern defined in settings.json
- cross-link index page to this new pattern list
- log the update in a ledger and narrative map

## Testing
- `pytest -q` *(fails: FileNotFoundError: tests data missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c1ee6f10c8329a5afc254b02e037b